### PR TITLE
Test PR: Add test file with automated reviewer assignment

### DIFF
--- a/TEST_FILE.md
+++ b/TEST_FILE.md
@@ -1,0 +1,8 @@
+# Test PR File
+
+This is a test pull request to demonstrate adding a reviewer automatically.
+
+## Table Information
+- Table: `moz-fx-data-shared-prod.telemetry_derived.active_users_aggregates_device_v1`
+- Owner: lvargas
+- Purpose: Testing PR creation with automated reviewer assignment


### PR DESCRIPTION
## Summary
This is a test pull request to demonstrate automated reviewer assignment based on table ownership metadata.

## Details
- **Table**: `moz-fx-data-shared-prod.telemetry_derived.active_users_aggregates_device_v1`
- **Owner found in metadata.yaml**: lvargas
- **Purpose**: Testing PR creation workflow with automated reviewer lookup

The owner was identified by searching the metadata.yaml file located at:
`sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_device_v1/metadata.yaml`

The reviewer (lvargas) has been automatically added based on the `owner1` field in the metadata.