### PR TITLE
docs: Enhance schema and add README for acoustic_derived.raw_recipient_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/acoustic_derived/raw_recipient_v1/README.md
+++ b/sql/moz-fx-data-shared-prod/acoustic_derived/raw_recipient_v1/README.md
@@ -1,0 +1,80 @@
+# Raw Recipient (Acoustic Campaign Data)
+
+## Overview
+
+The `raw_recipient_v1` table contains raw recipient-level event data exported from Acoustic Campaign platform. This table captures comprehensive email engagement metrics including sends, opens, clicks, bounces, and suppressions. The data is imported directly from Acoustic's CSV export and provides granular tracking of email campaign performance at the individual recipient level.
+
+**Data Source**: Acoustic Campaign API
+**Update Frequency**: Incremental daily loads
+**Retention**: 775 days (partitioned by submission_date)
+
+## Table Details
+
+- **Dataset**: `moz-fx-data-shared-prod.acoustic_derived`
+- **Table**: `raw_recipient_v1`
+- **Type**: Client-level data
+- **Partitioning**: Daily partitioned by `submission_date`
+- **Clustering**: `event_type`, `recipient_type`, `body_type`
+
+## Schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `recipient_id` | INTEGER | Unique identifier for the contact who received the email campaign |
+| `report_id` | INTEGER | Report identifier used for tracking and aggregating campaign metrics |
+| `mailing_id` | INTEGER | Unique identifier for the specific sent email mailing |
+| `campaign_id` | INTEGER | Campaign identifier linking events to their parent marketing campaign |
+| `content_id` | STRING | Identifier for the email content variant sent to the recipient |
+| `event_timestamp` | DATETIME | Timestamp of when the email event occurred in the API user's timezone |
+| `event_type` | STRING | Type of email engagement event (e.g., sent, opened, clicked, bounced) |
+| `recipient_type` | STRING | Classification of the recipient type who received the campaign email |
+| `body_type` | STRING | Format of the email body delivered to the recipient (HTML, text, or multipart) |
+| `click_name` | STRING | User-defined label for the clicked link or clickstream tracking element |
+| `url` | STRING | Full URL of the hyperlink clicked by the recipient |
+| `suppression_reason` | STRING | Reason why a contact was excluded from receiving the email (e.g., unsubscribed, bounced) |
+| `submission_date` | DATE | Date partition field representing when data was loaded into BigQuery |
+
+## Downstream Analysis Suggestions
+
+### 1. Campaign Performance Dashboard
+Aggregate email engagement metrics by campaign to calculate:
+- Open rates: `COUNT(DISTINCT CASE WHEN event_type = 'open' THEN recipient_id END) / COUNT(DISTINCT CASE WHEN event_type = 'sent' THEN recipient_id END)`
+- Click-through rates: `COUNT(DISTINCT CASE WHEN event_type = 'click' THEN recipient_id END) / COUNT(DISTINCT CASE WHEN event_type = 'sent' THEN recipient_id END)`
+- Bounce rates by campaign and recipient type
+- Time-series trends of engagement over submission_date
+
+### 2. Recipient Engagement Segmentation
+Analyze recipient behavior patterns:
+- Segment recipients by engagement level (high, medium, low) based on click and open frequency
+- Identify most engaged recipient_type segments
+- Track recipient lifecycle from first send to potential suppression
+- Compare engagement rates across different body_type formats (HTML vs text)
+
+### 3. Content Performance Analysis
+Evaluate content effectiveness:
+- Rank content_id variants by engagement metrics
+- Analyze click_name and url patterns to identify high-performing CTAs
+- Compare mailing_id performance within the same campaign
+- Identify optimal send times by analyzing event_timestamp patterns
+
+### 4. Suppression and Deliverability Analysis
+Monitor email health metrics:
+- Track suppression_reason trends over time to identify list quality issues
+- Calculate deliverability rates by recipient_type
+- Identify campaigns with unusually high suppression or bounce rates
+- Correlate suppression patterns with campaign characteristics
+
+## Data Quality Notes
+
+- The `event_timestamp` field uses the API user's timezone, not UTC
+- Records are partitioned by `submission_date` which should overlap with dates in `event_timestamp`
+- Some fields like `click_name` and `url` are only populated for click events
+- The `suppression_reason` field is only populated when contacts are suppressed
+
+## Owners
+
+- cbeck@mozilla.com
+
+## References
+
+- [Acoustic Campaign API Documentation](https://developer.goacoustic.com/acoustic-campaign/reference/rawrecipientdataexport)

--- a/sql/moz-fx-data-shared-prod/acoustic_derived/raw_recipient_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/acoustic_derived/raw_recipient_v1/schema.yaml
@@ -6,62 +6,62 @@ fields:
 - mode: NULLABLE
   name: recipient_id
   type: INTEGER
-  description: The ID of the contact associated with the event.
+  description: Unique identifier for the contact who received the email campaign
 
 - mode: NULLABLE
   name: report_id
   type: INTEGER
-  description: null
+  description: Report identifier used for tracking and aggregating campaign metrics
 
 - mode: NULLABLE
   name: mailing_id
   type: INTEGER
-  description: The ID of the Sent email associated with the event.
+  description: Unique identifier for the specific sent email mailing
 
 - mode: NULLABLE
   name: campaign_id
   type: INTEGER
-  description: The ID of the campaign associated with the event.
+  description: Campaign identifier linking events to their parent marketing campaign
 
 - mode: NULLABLE
   name: content_id
   type: STRING
-  description: The ID of the content associated with the event.
+  description: Identifier for the email content variant sent to the recipient
 
 - mode: NULLABLE
   name: event_timestamp
   type: DATETIME
-  description: The date and time of the event in the API user’s time zone.
+  description: Timestamp of when the email event occurred in the API user's timezone
 
 - mode: NULLABLE
   name: event_type
   type: STRING
-  description: The type of contact event.
+  description: Type of email engagement event (e.g., sent, opened, clicked, bounced)
 
 - mode: NULLABLE
   name: recipient_type
   type: STRING
-  description: The type of contact to whom the Acoustic Campaign sent the email.
+  description: Classification of the recipient type who received the campaign email
 
 - mode: NULLABLE
   name: body_type
   type: STRING
-  description: The body type the contact received.
+  description: Format of the email body delivered to the recipient (HTML, text, or multipart)
 
 - mode: NULLABLE
   name: click_name
   type: STRING
-  description: The user-specified name of the link or Clickstream.
+  description: User-defined label for the clicked link or clickstream tracking element
 
 - mode: NULLABLE
   name: url
   type: STRING
-  description: The hyperlink of a Clickthrough or Clickstream.
+  description: Full URL of the hyperlink clicked by the recipient
 
 - mode: NULLABLE
   name: suppression_reason
   type: STRING
-  description: The reason a contact was suppressed.
+  description: Reason why a contact was excluded from receiving the email (e.g., unsubscribed, bounced)
 
 
 ###### ETL fields
@@ -69,5 +69,4 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
-  description: Airflow's execution date should \
-    overlap with date inside event_timestamp field
+  description: Date partition field representing when data was loaded into BigQuery


### PR DESCRIPTION
## Summary

This PR enhances the documentation for the `moz-fx-data-shared-prod.acoustic_derived.raw_recipient_v1` table by:

- **Enhanced Column Descriptions**: Updated all 13 column descriptions with clearer, more contextual explanations
- **New README**: Added comprehensive table documentation including overview, schema details, and downstream analysis suggestions

## Changes

### schema.yaml
- Improved descriptions for all columns to provide better context about their purpose and usage
- Clarified technical details (e.g., timezone handling, event types, data formats)

### README.md (New)
- Table overview and data source information
- Detailed schema documentation with all column descriptions
- Four downstream analysis suggestions:
  1. Campaign Performance Dashboard
  2. Recipient Engagement Segmentation
  3. Content Performance Analysis
  4. Suppression and Deliverability Analysis
- Data quality notes and usage guidelines
- Owner and reference information

## Table Overview

The `raw_recipient_v1` table contains raw recipient-level event data from Acoustic Campaign platform, tracking email engagement metrics including sends, opens, clicks, bounces, and suppressions at the individual recipient level.

**Column Count**: 13 columns
**Data Retention**: 775 days
**Partitioning**: Daily by `submission_date`

Closes #62