### PR TITLE
Enhance documentation for acoustic_derived.raw_recipient_v1

### DIFF
--- a/bigquery_etl/schema/global.yaml
+++ b/bigquery_etl/schema/global.yaml
@@ -60,9 +60,21 @@ fields:
 - name: attribution_variation
   type: STRING
   description: The attribution variation key.
+- name: body_type
+  type: STRING
+  description: Email body format received by the contact (HTML, plain text, or multipart)
+- name: campaign_id
+  type: INTEGER
+  description: Identifier for the Acoustic Campaign associated with the mailing
+- name: click_name
+  type: STRING
+  description: User-defined name for the clicked link or clickstream identifier
 - name: client_id
   type: STRING
   description: A unique identifier (UUID) for the client.
+- name: content_id
+  type: STRING
+  description: Identifier for the email content or template used in the mailing
 - name: context_id
   type: STRING
   description: A unique identifier (UUID) for clients in contextual services user
@@ -101,6 +113,12 @@ fields:
 - name: document_id
   type: STRING
   description: The document ID specified in the URI when the client sent this message.
+- name: event_timestamp
+  type: DATETIME
+  description: Timestamp of the recipient event in the API user's time zone
+- name: event_type
+  type: STRING
+  description: Type of email event (e.g., sent, opened, clicked, bounced, unsubscribed)
 - name: is_default_browser
   type: BOOLEAN
   description: A flag indicating whether the browser is set as the default browser on the client side.
@@ -118,6 +136,9 @@ fields:
 - name: locale
   type: STRING
   description: Set of language- and/or country-based preferences for a user interface.
+- name: mailing_id
+  type: INTEGER
+  description: Unique identifier for the email mailing sent to the recipient
 - name: normalized_channel
   description: The normalized channel the application is being distributed on.
   type: STRING
@@ -156,6 +177,15 @@ fields:
 - name: profile_group_id
   type: STRING
   description: A UUID uniquely identifying the profile group, not shared with other telemetry data.
+- name: recipient_id
+  type: INTEGER
+  description: Unique identifier for the contact who received the email campaign
+- name: recipient_type
+  type: STRING
+  description: Classification of the recipient (e.g., contact, seed, test)
+- name: report_id
+  type: INTEGER
+  description: Identifier linking to the specific report generated for this recipient event
 - name: sample_id
   type: INTEGER
   description: A number, 0-99, that samples by client_id and allows filtering data for analysis.
@@ -181,6 +211,9 @@ fields:
 - name: submission_timestamp
   type: TIMESTAMP
   description: Timestamp when the ping is received on the server side.
+- name: suppression_reason
+  type: STRING
+  description: Reason the contact was suppressed from receiving the email (e.g., unsubscribed, bounced)
 - name: telemetry_sdk_build
   type: STRING
   description: The version of the Glean SDK at the time the ping was collected (e.g. 25.0.0).
@@ -190,3 +223,6 @@ fields:
   aliases:
   - updated_timestamp
   - updated_date
+- name: url
+  type: STRING
+  description: Full URL of the link clicked by the recipient

--- a/sql/moz-fx-data-shared-prod/acoustic_derived/raw_recipient_v1/README.md
+++ b/sql/moz-fx-data-shared-prod/acoustic_derived/raw_recipient_v1/README.md
@@ -1,0 +1,48 @@
+# Raw Recipient (Acoustic Data)
+
+## Overview
+
+This table imports raw recipient-level data exported from Acoustic Campaign, providing detailed email performance metrics at the individual contact level. The data includes comprehensive tracking of email events such as sends, opens, clicks, bounces, and unsubscribes, enabling granular analysis of email campaign effectiveness.
+
+## Data Source
+
+Data is exported from Acoustic Campaign via CSV files and ingested into BigQuery. The source API documentation can be found at: https://developer.goacoustic.com/acoustic-campaign/reference/rawrecipientdataexport
+
+## Table Characteristics
+
+- **Partition Field**: `submission_date` (day-level partitioning)
+- **Clustering**: `event_type`, `recipient_type`, `body_type`
+- **Incremental Load**: Yes
+- **Retention**: 775 days
+- **Table Type**: Client-level data
+
+## Key Columns
+
+- **recipient_id**: Unique identifier for each contact
+- **mailing_id**: Links to specific email mailing campaigns
+- **campaign_id**: Groups mailings under broader campaigns
+- **event_type**: Categorizes recipient actions (sent, opened, clicked, etc.)
+- **event_timestamp**: Precise timing of events in the API user's timezone
+- **url**: Captures clicked links for engagement analysis
+- **suppression_reason**: Tracks why contacts were excluded from mailings
+
+## Downstream Analysis Suggestions
+
+### 1. Email Campaign Performance Dashboard
+Analyze open rates, click-through rates, and conversion funnels by campaign and content type. Calculate engagement metrics by comparing event types (sent → opened → clicked) to identify high-performing campaigns and optimize future email strategies.
+
+### 2. Recipient Engagement Segmentation
+Segment recipients based on engagement patterns using `event_type` and `recipient_type`. Identify highly engaged users (multiple clicks/opens), inactive users, and suppressed contacts to tailor re-engagement campaigns and improve list health.
+
+### 3. Content and Link Performance Analysis
+Analyze `click_name` and `url` fields to determine which content elements and links drive the most engagement. Compare performance across different `body_type` formats (HTML vs. plain text) to optimize email design and content placement.
+
+### 4. Suppression and List Quality Monitoring
+Track suppression trends over time using `suppression_reason` to identify potential deliverability issues, monitor unsubscribe rates, and maintain list hygiene. Cross-reference with campaign characteristics to understand factors driving opt-outs.
+
+## Usage Notes
+
+- The table is clustered by event-related fields for efficient filtering on common query patterns
+- Partition filtering on `submission_date` is recommended for query performance
+- Event timestamps are in the API user's timezone; consider timezone conversion for analysis across regions
+- The data represents raw, unaggregated events and may require deduplication for certain analyses

--- a/sql/moz-fx-data-shared-prod/acoustic_derived/raw_recipient_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/acoustic_derived/raw_recipient_v1/schema.yaml
@@ -6,62 +6,62 @@ fields:
 - mode: NULLABLE
   name: recipient_id
   type: INTEGER
-  description: The ID of the contact associated with the event.
+  description: Unique identifier for the contact who received the email campaign
 
 - mode: NULLABLE
   name: report_id
   type: INTEGER
-  description: null
+  description: Identifier linking to the specific report generated for this recipient event
 
 - mode: NULLABLE
   name: mailing_id
   type: INTEGER
-  description: The ID of the Sent email associated with the event.
+  description: Unique identifier for the email mailing sent to the recipient
 
 - mode: NULLABLE
   name: campaign_id
   type: INTEGER
-  description: The ID of the campaign associated with the event.
+  description: Identifier for the Acoustic Campaign associated with the mailing
 
 - mode: NULLABLE
   name: content_id
   type: STRING
-  description: The ID of the content associated with the event.
+  description: Identifier for the email content or template used in the mailing
 
 - mode: NULLABLE
   name: event_timestamp
   type: DATETIME
-  description: The date and time of the event in the API user’s time zone.
+  description: Timestamp of the recipient event in the API user's time zone
 
 - mode: NULLABLE
   name: event_type
   type: STRING
-  description: The type of contact event.
+  description: Type of email event (e.g., sent, opened, clicked, bounced, unsubscribed)
 
 - mode: NULLABLE
   name: recipient_type
   type: STRING
-  description: The type of contact to whom the Acoustic Campaign sent the email.
+  description: Classification of the recipient (e.g., contact, seed, test)
 
 - mode: NULLABLE
   name: body_type
   type: STRING
-  description: The body type the contact received.
+  description: Email body format received by the contact (HTML, plain text, or multipart)
 
 - mode: NULLABLE
   name: click_name
   type: STRING
-  description: The user-specified name of the link or Clickstream.
+  description: User-defined name for the clicked link or clickstream identifier
 
 - mode: NULLABLE
   name: url
   type: STRING
-  description: The hyperlink of a Clickthrough or Clickstream.
+  description: Full URL of the link clicked by the recipient
 
 - mode: NULLABLE
   name: suppression_reason
   type: STRING
-  description: The reason a contact was suppressed.
+  description: Reason the contact was suppressed from receiving the email (e.g., unsubscribed, bounced)
 
 
 ###### ETL fields
@@ -69,5 +69,4 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
-  description: Airflow's execution date should \
-    overlap with date inside event_timestamp field
+  description: The date when the telemetry ping is received on the server side.


### PR DESCRIPTION
## Summary
- Enhanced column descriptions in `schema.yaml` with clear, concise descriptions for all 14 columns
- Created comprehensive `README.md` with table overview, key characteristics, and 4 downstream analysis suggestions
- Updated `global.yaml` with 11 new column definitions specific to Acoustic Campaign data

## Changes
### Schema Enhancements
All columns now have improved descriptions that provide context about their purpose and usage:
- `recipient_id`: Unique identifier for the contact who received the email campaign
- `report_id`: Identifier linking to the specific report generated for this recipient event
- `mailing_id`: Unique identifier for the email mailing sent to the recipient
- `campaign_id`: Identifier for the Acoustic Campaign associated with the mailing
- `content_id`: Identifier for the email content or template used in the mailing
- `event_timestamp`: Timestamp of the recipient event in the API user's time zone
- `event_type`: Type of email event (e.g., sent, opened, clicked, bounced, unsubscribed)
- `recipient_type`: Classification of the recipient (e.g., contact, seed, test)
- `body_type`: Email body format received by the contact (HTML, plain text, or multipart)
- `click_name`: User-defined name for the clicked link or clickstream identifier
- `url`: Full URL of the link clicked by the recipient
- `suppression_reason`: Reason the contact was suppressed from receiving the email (e.g., unsubscribed, bounced)
- `submission_date`: The date when the telemetry ping is received on the server side

### README Documentation
Created comprehensive documentation including:
- Table overview and data source information
- Table characteristics (partitioning, clustering, retention)
- Key columns explanation
- 4 downstream analysis suggestions:
  1. Email Campaign Performance Dashboard
  2. Recipient Engagement Segmentation
  3. Content and Link Performance Analysis
  4. Suppression and List Quality Monitoring

### Global Schema Updates
Added 11 new column definitions to `global.yaml` that can be reused across other Acoustic Campaign tables:
- `recipient_id`, `report_id`, `mailing_id`, `campaign_id`, `content_id`
- `event_timestamp`, `event_type`, `recipient_type`, `body_type`
- `click_name`, `url`, `suppression_reason`

🤖 Generated with Chicory AI