### PR TITLE
Add enhanced schema documentation for firefox_app_store_territory_source_type_report

### DIFF
--- a/bigquery_etl/schema/global.yaml
+++ b/bigquery_etl/schema/global.yaml
@@ -190,3 +190,39 @@ fields:
   aliases:
   - updated_timestamp
   - updated_date
+- name: app_id
+  type: INTEGER
+  mode: NULLABLE
+  description: Apple App Store application identifier for Firefox app
+- name: _fivetran_synced
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: Timestamp when Fivetran last synchronized this record
+- name: impressions
+  type: INTEGER
+  mode: NULLABLE
+  description: Total number of times app was viewed in App Store
+- name: impressions_unique_device
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique devices that generated impressions
+- name: meets_threshold
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Indicates if data meets Apple privacy threshold for reporting
+- name: page_views
+  type: INTEGER
+  mode: NULLABLE
+  description: Total views of the app product page in App Store
+- name: page_views_unique_device
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique devices that viewed the product page
+- name: source_type
+  type: STRING
+  mode: NULLABLE
+  description: Traffic source category for app discovery or acquisition
+- name: territory
+  type: STRING
+  mode: NULLABLE
+  description: Country or region where app metrics were recorded

--- a/sql/moz-fx-data-shared-prod/app_store/firefox_app_store_territory_source_type_report/README.md
+++ b/sql/moz-fx-data-shared-prod/app_store/firefox_app_store_territory_source_type_report/README.md
@@ -1,0 +1,124 @@
+# Firefox App Store Territory Source Type Report
+
+## Overview
+
+This view provides Apple App Store engagement metrics for Firefox iOS app, segmented by territory (country/region) and traffic source type. The data tracks how users discover and interact with Firefox in the App Store, including impressions and page views from different acquisition channels.
+
+**Data Source**: Apple App Store Connect via Fivetran
+**Timezone**: Pacific Time (PT) - Data represents full days from 12:00 AM to 11:59 PM PT
+**Update Frequency**: Daily
+**Reference**: [Apple App Store Connect Documentation](https://developer.apple.com/help/app-store-connect/view-sales-and-trends/download-and-view-reports)
+
+## Schema
+
+The table contains the following key dimensions and metrics:
+
+### Dimensions
+- **app_id**: Apple's unique identifier for the Firefox application
+- **date**: Report date (stored as timestamp at midnight PT)
+- **source_type**: Traffic source category (e.g., "App Referrer", "Web Referrer", "Unavailable", "Institutional Purchase")
+- **territory**: Country or region name
+
+### Metrics
+- **impressions**: Total number of times Firefox was viewed in the App Store
+- **impressions_unique_device**: Number of unique devices that generated impressions
+- **page_views**: Total views of Firefox product page
+- **page_views_unique_device**: Number of unique devices that viewed the product page
+
+### Metadata
+- **meets_threshold**: Boolean indicating whether metrics meet Apple's privacy threshold
+- **_fivetran_synced**: ETL sync timestamp from Fivetran
+
+## Important Notes
+
+### Timezone Handling
+The date field always shows midnight in the timestamp. No timezone conversion is applied in the view to avoid incorrectly shifting data by one day. All dates should be interpreted as Pacific Time.
+
+### Privacy Threshold
+Apple applies privacy thresholds to protect user privacy. When `meets_threshold` is false, the metrics may be suppressed or aggregated differently.
+
+## Downstream Analysis Suggestions
+
+### 1. Geographic Performance Analysis
+Identify which territories drive the most App Store engagement for Firefox:
+```sql
+SELECT
+  territory,
+  SUM(impressions) as total_impressions,
+  SUM(page_views) as total_page_views,
+  SAFE_DIVIDE(SUM(page_views), SUM(impressions)) as impression_to_pageview_rate
+FROM `moz-fx-data-shared-prod.app_store.firefox_app_store_territory_source_type_report`
+WHERE meets_threshold = TRUE
+  AND date >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+GROUP BY territory
+ORDER BY total_impressions DESC
+LIMIT 20;
+```
+
+### 2. Source Type Effectiveness
+Compare which traffic sources are most effective at converting impressions to page views:
+```sql
+SELECT
+  source_type,
+  SUM(impressions) as total_impressions,
+  SUM(page_views) as total_page_views,
+  SAFE_DIVIDE(SUM(page_views), SUM(impressions)) * 100 as conversion_rate_pct
+FROM `moz-fx-data-shared-prod.app_store.firefox_app_store_territory_source_type_report`
+WHERE meets_threshold = TRUE
+  AND source_type != 'Institutional Purchase'
+  AND date >= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
+GROUP BY source_type
+ORDER BY conversion_rate_pct DESC;
+```
+
+### 3. Trend Analysis by Territory and Source
+Track how engagement metrics evolve over time for key markets:
+```sql
+SELECT
+  DATE_TRUNC(date, WEEK) as week,
+  territory,
+  source_type,
+  SUM(impressions_unique_device) as unique_impressions,
+  SUM(page_views_unique_device) as unique_pageviews
+FROM `moz-fx-data-shared-prod.app_store.firefox_app_store_territory_source_type_report`
+WHERE meets_threshold = TRUE
+  AND territory IN ('United States', 'Germany', 'France', 'United Kingdom')
+  AND date >= DATE_SUB(CURRENT_DATE(), INTERVAL 180 DAY)
+GROUP BY week, territory, source_type
+ORDER BY week DESC, territory, source_type;
+```
+
+### 4. Cross-Funnel Analysis with Downloads
+Combine with download metrics to analyze the complete acquisition funnel:
+```sql
+SELECT
+  a.territory,
+  a.source_type,
+  SUM(a.page_views_unique_device) as unique_pageviews,
+  SUM(d.first_time_downloads) as first_time_downloads,
+  SAFE_DIVIDE(SUM(d.first_time_downloads), SUM(a.page_views_unique_device)) as pageview_to_download_rate
+FROM `moz-fx-data-shared-prod.app_store.firefox_app_store_territory_source_type_report` a
+LEFT JOIN `moz-fx-data-shared-prod.app_store.firefox_downloads_territory_source_type_report` d
+  ON a.date = d.date
+  AND a.territory = d.territory
+  AND a.source_type = d.source_type
+WHERE a.meets_threshold = TRUE
+  AND a.date >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+GROUP BY a.territory, a.source_type
+HAVING unique_pageviews > 100
+ORDER BY pageview_to_download_rate DESC;
+```
+
+## Related Tables
+
+- **firefox_downloads_territory_source_type_report**: Download metrics by territory and source
+- **firefox_usage_territory_source_type_report**: Usage metrics including active devices and sessions
+- **firefox_app_store_territory_web_referrer_report**: App Store metrics by web referrer
+- **firefox_downloads_territory_web_referrer_report**: Download metrics by web referrer
+
+## Data Quality Considerations
+
+- Records where `meets_threshold = FALSE` may have metrics suppressed for privacy
+- The `source_type` value "Unavailable" indicates Apple could not determine the source
+- "Institutional Purchase" source type typically represents volume purchase programs
+- Unique device counts may be approximate due to Apple's privacy-preserving methods

--- a/sql/moz-fx-data-shared-prod/app_store/firefox_app_store_territory_source_type_report/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/app_store/firefox_app_store_territory_source_type_report/schema.yaml
@@ -1,0 +1,41 @@
+fields:
+- name: app_id
+  type: INTEGER
+  mode: NULLABLE
+  description: Apple App Store application identifier for Firefox app
+- name: date
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: Report date in Pacific Time (PT) with timestamp at midnight
+- name: source_type
+  type: STRING
+  mode: NULLABLE
+  description: Traffic source category for app discovery or acquisition
+- name: territory
+  type: STRING
+  mode: NULLABLE
+  description: Country or region where app metrics were recorded
+- name: _fivetran_synced
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: Timestamp when Fivetran last synchronized this record
+- name: impressions
+  type: INTEGER
+  mode: NULLABLE
+  description: Total number of times app was viewed in App Store
+- name: impressions_unique_device
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique devices that generated impressions
+- name: meets_threshold
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Indicates if data meets Apple privacy threshold for reporting
+- name: page_views
+  type: INTEGER
+  mode: NULLABLE
+  description: Total views of the app product page in App Store
+- name: page_views_unique_device
+  type: INTEGER
+  mode: NULLABLE
+  description: Count of unique devices that viewed the product page


### PR DESCRIPTION
## Summary

This PR adds comprehensive schema documentation and metadata for the `moz-fx-data-shared-prod.app_store.firefox_app_store_territory_source_type_report` table.

### Changes Made

1. **Enhanced Schema Documentation** (`schema.yaml`)
   - Added detailed descriptions for all 10 columns
   - Includes data types and modes for each field
   - Descriptions tailored to Apple App Store context

2. **Comprehensive README** (`README.md`)
   - Overview of the table and data source
   - Schema documentation with dimensions and metrics
   - Important notes on timezone handling and privacy thresholds
   - 4 downstream analysis suggestions with example SQL queries
   - Related tables and data quality considerations

3. **Global Schema Updates** (`global.yaml`)
   - Added 9 new column definitions to the global schema catalog
   - Columns: `app_id`, `_fivetran_synced`, `impressions`, `impressions_unique_device`, `meets_threshold`, `page_views`, `page_views_unique_device`, `source_type`, `territory`

### Table Overview

This view provides Apple App Store engagement metrics for Firefox iOS app, segmented by territory and traffic source type. Data is sourced from Apple App Store Connect via Fivetran and represents user discovery and interaction patterns in the App Store.

**Key Metrics:**
- Impressions and unique devices viewing the app
- Page views and unique devices viewing the product page
- Segmented by territory (country/region) and source type

### Column Count
- Total columns: 10 (meets threshold for PR submission)

Fixes #86

---

🤖 Generated with enhanced AI-powered schema analysis