### PR TITLE
Deprecate deprecation_test_dataset.deprecation_test_table

### DIFF
--- a/sql/moz-fx-data-shared-prod/deprecation_test_dataset/deprecation_test_table/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/deprecation_test_dataset/deprecation_test_table/metadata.yaml
@@ -1,6 +1,7 @@
 friendly_name: Firefox Desktop Background Default Agent Derived
 description: |-
   Aggregate table for firefox desktop background default agent
+deprecated: true
 owners:
 - gkatre@mozilla.com
 labels:


### PR DESCRIPTION
## Summary
Automated deprecation of `deprecation_test_dataset.deprecation_test_table` based on usage analysis.

### Usage Analysis (Last 6 Months)
- **BigQuery Jobs**: 0 jobs referencing this table
- **Looker Models**: 0 models using this table
- **Looker Explores**: 0 explores using this table

### Lineage Check
- **Downstream Dependencies**: None found in DataHub

### Changes Made
- Added `deprecated: true` flag to metadata.yaml
- No view.sql files found to delete

### Technical Owner
@gkatre

---

🤖 Automated deprecation by Chicory AI