### PR TITLE
Enhance documentation for acoustic_derived.raw_recipient_v1 (Issue #98)

### DIFF
--- a/bigquery_etl/schema/global.yaml
+++ b/bigquery_etl/schema/global.yaml
@@ -60,9 +60,25 @@ fields:
 - name: attribution_variation
   type: STRING
   description: The attribution variation key.
+- name: body_type
+  type: STRING
+  mode: NULLABLE
+  description: Format of the email body content received by the contact (e.g., HTML, plain text)
+- name: campaign_id
+  type: INTEGER
+  mode: NULLABLE
+  description: Unique identifier for the marketing campaign in Acoustic
+- name: click_name
+  type: STRING
+  mode: NULLABLE
+  description: User-defined label for the clicked link or clickstream in the email
 - name: client_id
   type: STRING
   description: A unique identifier (UUID) for the client.
+- name: content_id
+  type: STRING
+  mode: NULLABLE
+  description: Unique identifier for the email content or template used in the mailing
 - name: context_id
   type: STRING
   description: A unique identifier (UUID) for clients in contextual services user
@@ -101,6 +117,14 @@ fields:
 - name: document_id
   type: STRING
   description: The document ID specified in the URI when the client sent this message.
+- name: event_timestamp
+  type: DATETIME
+  mode: NULLABLE
+  description: Timestamp when the email event occurred in the API user's timezone
+- name: event_type
+  type: STRING
+  mode: NULLABLE
+  description: Type of email interaction event (e.g., sent, opened, clicked, bounced, unsubscribed)
 - name: is_default_browser
   type: BOOLEAN
   description: A flag indicating whether the browser is set as the default browser on the client side.
@@ -118,6 +142,10 @@ fields:
 - name: locale
   type: STRING
   description: Set of language- and/or country-based preferences for a user interface.
+- name: mailing_id
+  type: INTEGER
+  mode: NULLABLE
+  description: Unique identifier for the specific email mailing that was sent
 - name: normalized_channel
   description: The normalized channel the application is being distributed on.
   type: STRING
@@ -156,6 +184,18 @@ fields:
 - name: profile_group_id
   type: STRING
   description: A UUID uniquely identifying the profile group, not shared with other telemetry data.
+- name: recipient_id
+  type: INTEGER
+  mode: NULLABLE
+  description: Unique identifier for the contact who received or interacted with the email campaign
+- name: recipient_type
+  type: STRING
+  mode: NULLABLE
+  description: Classification of the contact recipient in the Acoustic Campaign system
+- name: report_id
+  type: INTEGER
+  mode: NULLABLE
+  description: Acoustic report identifier associated with the email event
 - name: sample_id
   type: INTEGER
   description: A number, 0-99, that samples by client_id and allows filtering data for analysis.
@@ -181,6 +221,10 @@ fields:
 - name: submission_timestamp
   type: TIMESTAMP
   description: Timestamp when the ping is received on the server side.
+- name: suppression_reason
+  type: STRING
+  mode: NULLABLE
+  description: Reason why the contact was excluded from receiving the email
 - name: telemetry_sdk_build
   type: STRING
   description: The version of the Glean SDK at the time the ping was collected (e.g. 25.0.0).
@@ -190,3 +234,7 @@ fields:
   aliases:
   - updated_timestamp
   - updated_date
+- name: url
+  type: STRING
+  mode: NULLABLE
+  description: Full URL of the link clicked in the email

--- a/sql/moz-fx-data-shared-prod/acoustic_derived/raw_recipient_v1/README.md
+++ b/sql/moz-fx-data-shared-prod/acoustic_derived/raw_recipient_v1/README.md
@@ -1,0 +1,125 @@
+# Raw Recipient (Acoustic Campaign Data)
+
+## Overview
+
+This table contains raw recipient-level email event data exported from Acoustic Campaign (formerly Silverpop). It captures detailed metrics about email campaign performance, including sends, opens, clicks, bounces, and suppressions. The data is imported from CSV files exported via the Acoustic Campaign API.
+
+## Data Source
+
+- **Platform**: Acoustic Campaign
+- **Import Method**: CSV data export
+- **API Reference**: [Acoustic Campaign Raw Recipient Data Export](https://developer.goacoustic.com/acoustic-campaign/reference/rawrecipientdataexport)
+
+## Table Structure
+
+### Partitioning
+- **Field**: `submission_date`
+- **Type**: Daily partitioning
+- **Retention**: 775 days (~2 years)
+
+### Clustering
+Optimized for queries filtering on:
+- `event_type` - Email event categories
+- `recipient_type` - Contact classifications
+- `body_type` - Email format types
+
+## Key Columns
+
+### Identifiers
+- **recipient_id**: Unique contact identifier in Acoustic
+- **mailing_id**: Specific email send identifier
+- **campaign_id**: Marketing campaign identifier
+- **content_id**: Email template/content identifier
+- **report_id**: Associated report identifier
+
+### Event Data
+- **event_type**: Type of interaction (sent, opened, clicked, bounced, etc.)
+- **event_timestamp**: When the event occurred (API user's timezone)
+- **recipient_type**: Contact classification in Acoustic
+- **body_type**: Email format (HTML, plain text)
+
+### Engagement Details
+- **click_name**: Named link or clickstream label
+- **url**: Full clicked URL
+- **suppression_reason**: Why contact was excluded from receiving email
+
+### ETL Metadata
+- **submission_date**: Server-side ingestion date (aligns with event_timestamp)
+
+## Downstream Analysis Suggestions
+
+### 1. Email Campaign Performance Analysis
+Analyze open rates, click-through rates, and engagement metrics by campaign:
+```sql
+SELECT
+  campaign_id,
+  mailing_id,
+  COUNT(DISTINCT recipient_id) as total_recipients,
+  COUNTIF(event_type = 'opened') as opens,
+  COUNTIF(event_type = 'clicked') as clicks,
+  COUNTIF(event_type = 'bounced') as bounces,
+  SAFE_DIVIDE(COUNTIF(event_type = 'opened'), COUNT(DISTINCT recipient_id)) as open_rate,
+  SAFE_DIVIDE(COUNTIF(event_type = 'clicked'), COUNTIF(event_type = 'opened')) as click_to_open_rate
+FROM `moz-fx-data-shared-prod.acoustic_derived.raw_recipient_v1`
+WHERE submission_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+GROUP BY campaign_id, mailing_id
+ORDER BY total_recipients DESC
+```
+
+### 2. Link Performance and Content Engagement
+Identify top-performing links and content across campaigns:
+```sql
+SELECT
+  click_name,
+  url,
+  body_type,
+  COUNT(DISTINCT recipient_id) as unique_clickers,
+  COUNT(*) as total_clicks
+FROM `moz-fx-data-shared-prod.acoustic_derived.raw_recipient_v1`
+WHERE event_type = 'clicked'
+  AND submission_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 90 DAY)
+GROUP BY click_name, url, body_type
+ORDER BY unique_clickers DESC
+LIMIT 100
+```
+
+### 3. Recipient Behavior Segmentation
+Segment recipients by engagement patterns and types:
+```sql
+SELECT
+  recipient_type,
+  body_type,
+  COUNT(DISTINCT recipient_id) as unique_recipients,
+  COUNT(*) as total_events,
+  COUNTIF(event_type IN ('opened', 'clicked')) as engaged_events,
+  SAFE_DIVIDE(COUNTIF(event_type IN ('opened', 'clicked')), COUNT(*)) as engagement_rate
+FROM `moz-fx-data-shared-prod.acoustic_derived.raw_recipient_v1`
+WHERE submission_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 60 DAY)
+GROUP BY recipient_type, body_type
+ORDER BY unique_recipients DESC
+```
+
+### 4. Suppression and Deliverability Analysis
+Monitor email deliverability issues and suppression patterns:
+```sql
+SELECT
+  suppression_reason,
+  event_type,
+  DATE_TRUNC(submission_date, WEEK) as week,
+  COUNT(DISTINCT recipient_id) as affected_recipients,
+  COUNT(*) as event_count
+FROM `moz-fx-data-shared-prod.acoustic_derived.raw_recipient_v1`
+WHERE suppression_reason IS NOT NULL
+  OR event_type IN ('bounced', 'unsubscribed', 'suppressed')
+GROUP BY suppression_reason, event_type, week
+ORDER BY week DESC, event_count DESC
+```
+
+## Owner
+
+- **Email**: gkatre@mozilla.com
+
+## Additional Resources
+
+- [Acoustic Campaign Documentation](https://developer.goacoustic.com/acoustic-campaign/docs)
+- [Acoustic Campaign API Reference](https://developer.goacoustic.com/acoustic-campaign/reference)

--- a/sql/moz-fx-data-shared-prod/acoustic_derived/raw_recipient_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/acoustic_derived/raw_recipient_v1/schema.yaml
@@ -1,67 +1,65 @@
-fields:
-
 # source:
 # https://developer.goacoustic.com/acoustic-campaign/reference/rawrecipientdataexport
 
 - mode: NULLABLE
   name: recipient_id
   type: INTEGER
-  description: The ID of the contact associated with the event.
+  description: Unique identifier for the contact who received or interacted with the email campaign
 
 - mode: NULLABLE
   name: report_id
   type: INTEGER
-  description: null
+  description: Acoustic report identifier associated with the email event
 
 - mode: NULLABLE
   name: mailing_id
   type: INTEGER
-  description: The ID of the Sent email associated with the event.
+  description: Unique identifier for the specific email mailing that was sent
 
 - mode: NULLABLE
   name: campaign_id
   type: INTEGER
-  description: The ID of the campaign associated with the event.
+  description: Unique identifier for the marketing campaign in Acoustic
 
 - mode: NULLABLE
   name: content_id
   type: STRING
-  description: The ID of the content associated with the event.
+  description: Unique identifier for the email content or template used in the mailing
 
 - mode: NULLABLE
   name: event_timestamp
   type: DATETIME
-  description: The date and time of the event in the API user’s time zone.
+  description: Timestamp when the email event occurred in the API user's timezone
 
 - mode: NULLABLE
   name: event_type
   type: STRING
-  description: The type of contact event.
+  description: Type of email interaction event (e.g., sent, opened, clicked, bounced, unsubscribed)
 
 - mode: NULLABLE
   name: recipient_type
   type: STRING
-  description: The type of contact to whom the Acoustic Campaign sent the email.
+  description: Classification of the contact recipient in the Acoustic Campaign system
 
 - mode: NULLABLE
   name: body_type
   type: STRING
-  description: The body type the contact received.
+  description: Format of the email body content received by the contact (e.g., HTML, plain text)
 
 - mode: NULLABLE
   name: click_name
   type: STRING
-  description: The user-specified name of the link or Clickstream.
+  description: User-defined label for the clicked link or clickstream in the email
 
 - mode: NULLABLE
   name: url
   type: STRING
-  description: The hyperlink of a Clickthrough or Clickstream.
+  description: Full URL of the link clicked in the email
 
 - mode: NULLABLE
   name: suppression_reason
   type: STRING
-  description: The reason a contact was suppressed.
+  description: Reason why the contact was excluded from receiving the email
 
 
 ###### ETL fields
@@ -69,5 +67,4 @@ fields:
 - mode: NULLABLE
   name: submission_date
   type: DATE
-  description: Airflow's execution date should \
-    overlap with date inside event_timestamp field
+  description: The date when the telemetry ping is received on the server side.


### PR DESCRIPTION
## Summary

This PR enhances the documentation for `moz-fx-data-shared-prod.acoustic_derived.raw_recipient_v1` by:

- **Enhanced schema.yaml**: Added comprehensive descriptions for all 13 columns based on Acoustic Campaign API documentation and data context
- **New README.md**: Created detailed table documentation including:
  - Table overview and data source information
  - Partitioning and clustering details
  - Key column descriptions organized by category
  - 4 downstream analysis suggestions with example SQL queries
- **Updated global.yaml**: Added 12 new Acoustic Campaign-specific column definitions for reuse across other tables

## Changes

### Schema Enhancements
All columns now have clear, concise descriptions explaining their purpose:
- Identifier columns (recipient_id, mailing_id, campaign_id, etc.)
- Event data columns (event_type, event_timestamp, etc.)
- Engagement details (click_name, url, suppression_reason)
- ETL metadata (submission_date from global.yaml)

### Documentation
The new README provides:
1. **Email Campaign Performance Analysis** - Track opens, clicks, and engagement metrics
2. **Link Performance and Content Engagement** - Identify top-performing links
3. **Recipient Behavior Segmentation** - Analyze engagement patterns by recipient type
4. **Suppression and Deliverability Analysis** - Monitor email deliverability issues

### Global Schema Updates
Added 12 new columns to global.yaml for reuse:
- body_type, campaign_id, click_name, content_id, event_timestamp, event_type
- mailing_id, recipient_id, recipient_type, report_id, suppression_reason, url

## Related Issue

Closes #98

---

🤖 Generated with Chicory AI