### PR TITLE
Deprecate pocket_usage asset - No usage detected in last 6 months

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.pocket_usage`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`

--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
@@ -18,3 +18,4 @@ bigquery:
   clustering:
     fields:
       - event_name
+deprecated: true


### PR DESCRIPTION
## Summary
This PR deprecates the `pocket_usage` asset and its related tables as no usage has been detected in the last 6 months.

### Assets Deprecated:
- **moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1** (source table)
- **moz-fx-data-shared-prod.pocket.pocket_usage** (view)
- **mozdata.pocket.pocket_usage** (downstream view)

### Usage Analysis (Last 6 Months):
- **BigQuery Jobs**: 0 jobs
- **Looker Models**: 0 models  
- **Looker Explores**: 0 explores

### Downstream Dependencies Check:
Checked downstream dependencies:
- `mozdata.pocket.pocket_usage` - No usage detected
- `moz-fx-data-shared-prod.pocket.pocket_usage` - No usage detected

### Changes Made:
1. ✅ Added `deprecated: true` to `metadata.yaml` for `pocket_usage_v1`
2. ✅ Deleted `view.sql` file from `moz-fx-data-shared-prod.pocket.pocket_usage`

### Owner:
@gkatre (gkatre@mozilla.com)

---
🤖 Generated by Chicory AI Deprecation Agent