### PR TITLE
Deprecate nt_visits_to_sessions_conversion_factors_daily view

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads/nt_visits_to_sessions_conversion_factors_daily/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/ads/nt_visits_to_sessions_conversion_factors_daily/metadata.yaml
@@ -11,3 +11,4 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:mozilla-confidential
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/ads/nt_visits_to_sessions_conversion_factors_daily/view.sql
+++ b/sql/moz-fx-data-shared-prod/ads/nt_visits_to_sessions_conversion_factors_daily/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.ads.nt_visits_to_sessions_conversion_factors_daily`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.ads_derived.nt_visits_to_sessions_conversion_factors_daily_v1`


### PR DESCRIPTION
## Summary
This PR deprecates the `nt_visits_to_sessions_conversion_factors_daily` view in the ads dataset as it has shown no usage in the last 6 months.

### Changes Made
- Added `deprecated: true` flag to `metadata.yaml` for the view in `moz-fx-data-shared-prod.ads.nt_visits_to_sessions_conversion_factors_daily`
- Deleted the associated `view.sql` file

### Usage Analysis (Last 6 Months)
- **BigQuery Jobs**: 0 jobs referencing this asset
- **Looker Models**: 0 models using this asset
- **Looker Explores**: 0 explores using this asset

### Additional Context
- The base table `ads_derived.nt_visits_to_sessions_conversion_factors_daily_v1` was already marked as deprecated
- No downstream dependencies with active usage were found
- DataHub confirmed no active lineage dependencies

### Technical Owners
@sbetancourt @cmorales @cbeck @lvargas

Please review and approve this deprecation.