### PR TITLE
Deprecate pocket_usage - No usage detected in last 6 months

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.pocket_usage`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`

--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   schedule: daily
   table_type: aggregate
   owner1: gkatre@mozilla.com
+deprecated: true
 scheduling:
   dag_name: bqetl_pocket
 bigquery:


### PR DESCRIPTION
## Summary

This PR deprecates the `pocket_usage` table as it has shown no usage activity in the last 6 months and has no downstream dependencies.

### Usage Analysis Results (Last 6 Months)
- **BigQuery Jobs**: 0 jobs
- **Looker Models**: 0 models  
- **Looker Explores**: 0 explores

### Downstream Dependencies
No downstream dependencies detected in DataHub lineage.

### Changes Made
1. ✅ Added `deprecated: true` to `metadata.yaml` for `pocket_derived.pocket_usage_v1`
2. ✅ Deleted `view.sql` file for `pocket.pocket_usage`

### Technical Owner
@gkatre (gkatre@mozilla.com)

---

**Deprecation Status**: ✅ **Approved for Deprecation**
- All usage checks returned 0 results
- No downstream dependencies found
- Safe to deprecate per automated deprecation agent analysis