### PR TITLE
Deprecate pocket_usage table - No usage detected

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.pocket_usage`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`

--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
@@ -1,6 +1,7 @@
 friendly_name: Pocket usage by event type
 description: |-
   Percentage of DAU for Pocket usage by event type for each channel
+deprecated: true
 owners:
   - gkatre@mozilla.com
 labels:


### PR DESCRIPTION
## Summary

This PR marks the `pocket_usage` table for deprecation based on automated usage analysis.

### Usage Analysis (Last 6 Months)
- **BigQuery Jobs**: 0
- **Looker Models**: 0
- **Looker Explores**: 0

### Changes Made
- ✅ Added `deprecated: true` to `pocket_derived.pocket_usage_v1` metadata.yaml
- ✅ Deleted `moz-fx-data-shared-prod.pocket.pocket_usage` view.sql file

### Dependency Analysis
- No downstream dependencies detected for this asset
- The mozdata.pocket.pocket_usage view also has no downstream dependencies

### Assets Affected
- `moz-fx-data-shared-prod.pocket.pocket_usage` (view)
- `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1` (base table)

### Technical Owner
@gkatre - Please review and approve if this deprecation is appropriate.

---
🤖 This PR was generated automatically by the Deprecation Agent