### PR TITLE
Deprecate pocket_usage_v1 table and view due to no usage in last 6 months

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.pocket_usage`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`

--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
@@ -18,3 +18,4 @@ bigquery:
   clustering:
     fields:
       - event_name
+deprecated: true


### PR DESCRIPTION
## Summary
This PR deprecates the `pocket_usage_v1` table and its associated view due to no usage detected in the last 6 months.

### Assets Deprecated
- **Table**: `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`
- **View**: `moz-fx-data-shared-prod.pocket.pocket_usage`
- **View**: `mozdata.pocket.pocket_usage` (auto-generated from shared-prod view)

### Usage Analysis (Last 6 Months)
- **BigQuery Jobs**: 0
- **Looker Models**: 0  
- **Looker Explores**: 0

### Dependency Analysis
All downstream dependencies were checked and also show no usage:
- `moz-fx-data-shared-prod.pocket.pocket_usage` - 0 jobs, 0 models, 0 explores
- `mozdata.pocket.pocket_usage` - 0 jobs, 0 models, 0 explores

### Changes Made
1. ✅ Added `deprecated: true` to `sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml`
2. ✅ Deleted `sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql`

### Owner
- @gkatre (gkatre@mozilla.com)

### Note
Last usage detected: January 9, 2025 (7+ months ago)
- 30 total jobs over 12 months
- 3 unique users: gkatre@mozilla.com, vsabino@mozilla.com, and default-workloads service account

---

🤖 Generated by Chicory AI Deprecation Agent