### PR TITLE
Deprecate pocket_usage view - No usage detected in last 6 months

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/metadata.yaml
@@ -1,0 +1,8 @@
+friendly_name: Pocket usage by event type
+description: |-
+  Percentage of DAU for Pocket usage by event type for each channel
+owners:
+  - gkatre@mozilla.com
+labels:
+  owner1: gkatre@mozilla.com
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.pocket_usage`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`


### PR DESCRIPTION
## Summary
This PR deprecates the `moz-fx-data-shared-prod.pocket.pocket_usage` view as part of automated asset deprecation workflow.

### Usage Analysis (Last 6 Months)
- **BigQuery Jobs**: 0 jobs found ❌
- **Looker Models**: 0 models found ❌
- **Looker Explores**: 0 explores found ❌

### Downstream Dependencies
- **No downstream dependencies found** ✅

### Changes Made
- ✅ Added `metadata.yaml` with `deprecated: true` flag for the view
- ✅ Deleted `view.sql` file

### Asset Details
- **Dataset**: `moz-fx-data-shared-prod.pocket`
- **Table**: `pocket_usage`
- **Type**: View (references `pocket_derived.pocket_usage_v1`)
- **Owner**: gkatre@mozilla.com

---

**Note**: This view had no usage activity detected across BigQuery jobs, Looker models, or Looker explores in the last 6 months, and has no downstream dependencies.

**Generated by Chicory AI Deprecation Agent**