### PR TITLE
Deprecate pocket_usage_v1 - No usage detected in last 6 months

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.pocket_usage`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`

--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   schedule: daily
   table_type: aggregate
   owner1: gkatre@mozilla.com
+deprecated: true
 scheduling:
   dag_name: bqetl_pocket
 bigquery:


### PR DESCRIPTION
## Summary

This PR deprecates `pocket_derived.pocket_usage_v1` and its associated view following the automated deprecation workflow.

### Usage Analysis (Last 6 Months)
- **BigQuery Jobs**: 0
- **Looker Models**: 0  
- **Looker Explores**: 0

### Downstream Dependencies Checked
The following downstream dependencies were also analyzed and showed no usage:
- `mozdata.pocket.pocket_usage` (0 jobs, 0 models, 0 explores)
- `moz-fx-data-shared-prod.pocket.pocket_usage` (0 jobs, 0 models, 0 explores)

### Changes Made
- ✅ Added `deprecated: true` flag to `metadata.yaml` for `pocket_derived.pocket_usage_v1`
- ✅ Deleted `view.sql` for `moz-fx-data-shared-prod.pocket.pocket_usage`

### Owner
@gkatre - Please review this deprecation based on the usage analysis above.

---

🤖 Generated by Chicory AI Deprecation Agent