### PR TITLE
Deprecate pocket_usage_v1 and associated views

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.pocket_usage`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`

--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
@@ -8,6 +8,7 @@ labels:
   schedule: daily
   table_type: aggregate
   owner1: gkatre@mozilla.com
+deprecated: true
 scheduling:
   dag_name: bqetl_pocket
 bigquery:


### PR DESCRIPTION
## Summary
This PR deprecates `pocket_usage_v1` and its associated view due to zero usage detected in the last 6 months.

### Changes Made
- Added `deprecated: true` flag to `sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml`
- Deleted `sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql`

### Usage Analysis (Last 6 Months)
- **BigQuery Jobs**: 0
- **Looker Models**: 0
- **Looker Explores**: 0

### Downstream Dependencies
The following downstream dependencies were also verified and showed zero usage:
- `moz-fx-data-shared-prod.pocket.pocket_usage`
- `mozdata.pocket.pocket_usage`

### Technical Owner
@gkatre

---
🤖 Generated by Chicory AI Deprecation Agent