### PR TITLE
Deprecate pocket_usage - No usage detected in last 6 months

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.pocket_usage`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`

--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
@@ -18,3 +18,4 @@ bigquery:
   clustering:
     fields:
       - event_name
+deprecated: true


### PR DESCRIPTION
## Deprecation Summary

This PR marks `pocket_usage` assets for deprecation after automated usage analysis revealed zero activity across all monitoring sources for the past 6 months.

## Assets Affected

### Primary Asset
- **Table**: `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`
- **Owner**: @gkatre (gkatre@mozilla.com)

### Downstream Dependencies (Also Unused)
- `moz-fx-data-shared-prod.pocket.pocket_usage` (view)
- `mozdata.pocket.pocket_usage` (auto-generated view)

## Usage Analysis Results

### pocket_usage_v1 (Primary Table)
- **BigQuery Jobs**: 0 jobs in last 6 months
- **Looker Models**: 0 models referencing this asset
- **Looker Explores**: 0 explores using this asset

### Downstream Dependencies
Both downstream views also showed zero usage:
- **moz-fx-data-shared-prod.pocket.pocket_usage**: 0 jobs, 0 models, 0 explores
- **mozdata.pocket.pocket_usage**: 0 jobs, 0 models, 0 explores

## Changes Made

1. ✅ Updated `sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml` 
   - Added `deprecated: true` flag
2. ✅ Deleted `sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql`
   - Removed view definition for shared-prod pocket schema

## DataHub Lineage

Verified downstream dependencies through DataHub lineage analysis showing only the two view dependencies listed above, both with no usage.

## Next Steps

After this PR is merged:
- The `deprecated: true` flag will signal to consumers that this asset is no longer maintained
- The view will no longer be created/updated in BigQuery
- Consider scheduling the table for deletion after appropriate notification period

---

**Automated Deprecation Analysis** - Generated based on 6-month usage monitoring across BigQuery jobs, Looker models, and Looker explores.