### PR TITLE
Deprecate pocket.pocket_usage - No usage detected in last 6 months

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/metadata.yaml
@@ -1,0 +1,5 @@
+friendly_name: Pocket Usage
+description: View for Pocket usage data (DEPRECATED - No usage detected in last 6 months)
+owners: []
+labels: {}
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.pocket_usage`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`


### PR DESCRIPTION
## Summary

This PR deprecates `moz-fx-data-shared-prod.pocket.pocket_usage` due to zero usage detected in the last 6 months.

## Usage Analysis (Last 6 Months)
- **BigQuery Jobs**: 0
- **Looker Models**: 0  
- **Looker Explores**: 0

## Dependency Analysis
- **Downstream Dependencies**: None detected in DataHub

## Changes Made
- ✅ Created `metadata.yaml` with `deprecated: true` flag
- ✅ Deleted `view.sql` file

## Additional Information
- No corresponding view found in mozdata dataset
- No downstream dependencies require recursive deprecation
- Asset is safe to deprecate

---
*Automated deprecation process completed*