### PR TITLE
Deprecate pocket_usage - No usage detected in last 6 months

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.pocket_usage`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`

--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
@@ -18,3 +18,4 @@ bigquery:
   clustering:
     fields:
       - event_name
+deprecated: true


### PR DESCRIPTION
## Summary
This PR deprecates the `pocket_usage` asset as it shows no usage in the last 6 months.

### Usage Analysis (Last 6 Months)
- **BigQuery Jobs**: 0 jobs
- **Looker Models**: 0 models  
- **Looker Explores**: 0 explores

### Changes Made
1. Added `deprecated: true` flag to `pocket_derived.pocket_usage_v1/metadata.yaml`
2. Deleted the view file `pocket.pocket_usage/view.sql`

### Dependencies
- **Downstream Dependencies**: None detected via DataHub lineage

### Owner
- Technical Owner: gkatre@mozilla.com

### Assets Affected
- `moz-fx-data-shared-prod.pocket.pocket_usage` (view - deleted)
- `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1` (table - marked deprecated)

Please review and approve this deprecation.

cc: @gkatre