### PR TITLE
Deprecate pocket_usage table - No usage detected

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.pocket_usage`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`

--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
@@ -18,3 +18,4 @@ bigquery:
   clustering:
     fields:
       - event_name
+deprecated: true


### PR DESCRIPTION
## Summary
This PR deprecates the `pocket_usage` table as no usage has been detected in the last 6 months.

### Usage Analysis (Last 6 Months)
- **BigQuery Jobs**: 0 jobs found
- **Looker Models**: 0 models found
- **Looker Explores**: 0 explores found
- **DataHub Downstream Dependencies**: None

### Changes Made
- Added `deprecated: true` flag to `pocket_derived/pocket_usage_v1/metadata.yaml`
- Deleted `pocket/pocket_usage/view.sql` file

### Technical Owner
@gkatre (gkatre@mozilla.com)

### Deprecation Status
✅ **APPROVED FOR DEPRECATION** - No usage detected and no downstream dependencies found.

---
*This PR was generated as part of the automated data asset deprecation workflow.*