### PR TITLE
Deprecate pocket_usage - No usage detected in last 6 months

### DIFF
--- a/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
+++ b/sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql
@@ -1,7 +1,0 @@
-CREATE OR REPLACE VIEW
-  `moz-fx-data-shared-prod.pocket.pocket_usage`
-AS
-SELECT
-  *
-FROM
-  `moz-fx-data-shared-prod.pocket_derived.pocket_usage_v1`

--- a/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml
@@ -18,3 +18,4 @@ bigquery:
   clustering:
     fields:
       - event_name
+deprecated: true


### PR DESCRIPTION
## Summary
This PR deprecates the `moz-fx-data-shared-prod.pocket.pocket_usage` asset due to zero usage detected in the last 6 months.

### Usage Analysis (Last 6 Months)
- **BigQuery Jobs**: 0 jobs
- **Looker Models**: 0 models
- **Looker Explores**: 0 explores
- **Downstream Dependencies**: None

### Changes Made
- Added `deprecated: true` to `sql/moz-fx-data-shared-prod/pocket_derived/pocket_usage_v1/metadata.yaml`
- Deleted `sql/moz-fx-data-shared-prod/pocket/pocket_usage/view.sql`

### Owner
- @gkatre (gkatre@mozilla.com)

### Lineage Check
No downstream dependencies were found for this asset, making it safe to deprecate.

---
*This deprecation was automatically generated based on usage analysis.*